### PR TITLE
Support audit subresource for entities

### DIFF
--- a/src/Api/Query/Segments/ById/AbstractByIdSegment.php
+++ b/src/Api/Query/Segments/ById/AbstractByIdSegment.php
@@ -8,10 +8,12 @@ use Evgeek\Moysklad\Api\Query\Segments\AbstractCommonSegment;
 use Evgeek\Moysklad\Api\Query\Traits\Actions\DeleteTrait;
 use Evgeek\Moysklad\Api\Query\Traits\Actions\UpdateTrait;
 use Evgeek\Moysklad\Api\Query\Traits\Segments\ById\ByIdCommonTrait;
+use Evgeek\Moysklad\Api\Query\Traits\Segments\AuditTrait;
 
 abstract class AbstractByIdSegment extends AbstractCommonSegment
 {
     use ByIdCommonTrait;
+    use AuditTrait;
     use DeleteTrait;
     use UpdateTrait;
 }

--- a/src/Api/Query/Segments/Methods/Nested/AuditSegment.php
+++ b/src/Api/Query/Segments/Methods/Nested/AuditSegment.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evgeek\Moysklad\Api\Query\Segments\Methods\Nested;
+
+use Evgeek\Moysklad\Api\Query\Segments\Methods\AbstractMethodNamedSegment;
+use Evgeek\Moysklad\Api\Query\Traits\Segments\ById\ByIdCommonTrait;
+use Evgeek\Moysklad\Dictionaries\Segment;
+
+class AuditSegment extends AbstractMethodNamedSegment
+{
+    use ByIdCommonTrait;
+
+    public const SEGMENT = Segment::AUDIT;
+}

--- a/src/Api/Query/Traits/Segments/AuditTrait.php
+++ b/src/Api/Query/Traits/Segments/AuditTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evgeek\Moysklad\Api\Query\Traits\Segments;
+
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
+
+trait AuditTrait
+{
+    /**
+     * Аудит сущности.
+     *
+     * <code>
+     * $audit = $ms->query()
+     *  ->entity()
+     *  ->customerorder()
+     *  ->byId('fb72fc83-7ef5-11e3-ad1c-002590a28eca')
+     *  ->audit()
+     *  ->get();
+     * </code>
+     */
+    public function audit(): AuditSegment
+    {
+        return $this->resolveNamedBuilder(AuditSegment::class);
+    }
+}

--- a/tests/Unit/Api/Query/Segments/ById/ByIdCommissionReportInSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdCommissionReportInSegmentTest.php
@@ -4,6 +4,7 @@ namespace Evgeek\Tests\Unit\Api\Query\Segments\ById;
 
 use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdCommissionReportInSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\ReturnToCommissionerPositionsSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdCommissionReportInSegment */
@@ -15,6 +16,7 @@ class ByIdCommissionReportInSegmentTest extends ByIdSegmentTestCase
     {
         return [
             ['returntocommissionerpositions', ReturnToCommissionerPositionsSegment::class, Segment::RETURNTOCOMMISSIONERPOSITIONS],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/ById/ByIdEmployeeSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdEmployeeSegmentTest.php
@@ -4,6 +4,7 @@ namespace Evgeek\Tests\Unit\Api\Query\Segments\ById;
 
 use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdEmployeeSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\SecuritySegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdEmployeeSegment */
@@ -15,6 +16,7 @@ class ByIdEmployeeSegmentTest extends ByIdSegmentTestCase
     {
         return [
             ['security', SecuritySegment::class, Segment::SECURITY],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/ById/ByIdOrganizationSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdOrganizationSegmentTest.php
@@ -4,6 +4,7 @@ namespace Evgeek\Tests\Unit\Api\Query\Segments\ById;
 
 use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdOrganizationSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AccountsSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdOrganizationSegment */
@@ -15,6 +16,7 @@ class ByIdOrganizationSegmentTest extends ByIdSegmentTestCase
     {
         return [
             ['accounts', AccountsSegment::class, Segment::ACCOUNTS],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/ById/ByIdProcessingPlanSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdProcessingPlanSegmentTest.php
@@ -6,6 +6,7 @@ use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdProcessingPlanSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\MaterialsSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\ProductsSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\StagesSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdProcessingPlanSegment */
@@ -19,6 +20,7 @@ class ByIdProcessingPlanSegmentTest extends ByIdSegmentTestCase
             ['stages', StagesSegment::class, Segment::STAGES],
             ['materials', MaterialsSegment::class, Segment::MATERIALS],
             ['products', ProductsSegment::class, Segment::PRODUCTS],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/ById/ByIdProcessingSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdProcessingSegmentTest.php
@@ -5,6 +5,7 @@ namespace Evgeek\Tests\Unit\Api\Query\Segments\ById;
 use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdProcessingSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\ProcessingPositionMaterialSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\ProcessingPositionResultSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdProcessingSegment */
@@ -17,6 +18,7 @@ class ByIdProcessingSegmentTest extends ByIdSegmentTestCase
         return [
             ['materials', ProcessingPositionMaterialSegment::class, Segment::MATERIALS],
             ['products', ProcessingPositionResultSegment::class, Segment::PRODUCTS],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/ById/ByIdRetailStoreSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/ById/ByIdRetailStoreSegmentTest.php
@@ -4,6 +4,7 @@ namespace Evgeek\Tests\Unit\Api\Query\Segments\ById;
 
 use Evgeek\Moysklad\Api\Query\Segments\ById\ByIdRetailStoreSegment;
 use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\CashiersSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
 use Evgeek\Moysklad\Dictionaries\Segment;
 
 /** @covers \Evgeek\Moysklad\Api\Query\Segments\ById\ByIdRetailStoreSegment */
@@ -15,6 +16,7 @@ class ByIdRetailStoreSegmentTest extends ByIdSegmentTestCase
     {
         return [
             ['cashiers', CashiersSegment::class, Segment::CASHIERS],
+            ['audit', AuditSegment::class, Segment::AUDIT],
         ];
     }
 }

--- a/tests/Unit/Api/Query/Segments/Methods/Nested/AuditSegmentTest.php
+++ b/tests/Unit/Api/Query/Segments/Methods/Nested/AuditSegmentTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Evgeek\Tests\Unit\Api\Query\Segments\Methods\Nested;
+
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
+use Evgeek\Moysklad\Dictionaries\Segment;
+use Evgeek\Tests\Unit\Api\Query\Segments\SegmentTestCase;
+
+/**
+ * @covers \Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment
+ */
+class AuditSegmentTest extends SegmentTestCase
+{
+    protected string $builderClass = AuditSegment::class;
+
+    public static function methodsWithCorrespondingSegmentClass(): array
+    {
+        return [];
+    }
+
+    public function testMethodReturnsCorrectClass(string $method = '', string $expectedSegment = '', string $expectedSegmentClass = '', array $parent = []): void
+    {
+        $this->markTestSkipped('AuditSegment has no nested segments to test.');
+    }
+
+    public function testSegmentConstant(): void
+    {
+        $this->assertSame(Segment::AUDIT, AuditSegment::SEGMENT);
+    }
+}

--- a/tests/Unit/Api/Query/Traits/Segments/AuditTraitTest.php
+++ b/tests/Unit/Api/Query/Traits/Segments/AuditTraitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Evgeek\Tests\Unit\Api\Query\Traits\Segments;
+
+use Evgeek\Moysklad\Api\Query\AbstractBuilder;
+use Evgeek\Moysklad\Api\Query\Segments\AbstractCommonSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\AbstractMethodNamedSegment;
+use Evgeek\Moysklad\Api\Query\Segments\Methods\Nested\AuditSegment;
+use Evgeek\Moysklad\Api\Query\Traits\Segments\AuditTrait;
+use Evgeek\Tests\Unit\Api\Query\Traits\TraitTestCase;
+
+/** @covers \Evgeek\Moysklad\Api\Query\Traits\Segments\AuditTrait */
+class AuditTraitTest extends TraitTestCase
+{
+    public function testReturnsCorrectClass(): void
+    {
+        $builder = (new class($this->api, static::PREV_PATH, static::PARAMS, 'test_segment') extends AbstractCommonSegment {
+            use AuditTrait;
+        })->audit();
+
+        $this->assertInstanceOf(AuditSegment::class, $builder);
+        $this->assertInstanceOf(AbstractMethodNamedSegment::class, $builder);
+        $this->assertInstanceOf(AbstractBuilder::class, $builder);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AuditSegment` for nested audit endpoints
- add `AuditTrait` and integrate it into by-id segments
- test `AuditTrait` and various by-id segments for the audit path
- add dedicated test for the nested `AuditSegment`

## Testing
- `make test-unit`